### PR TITLE
Removing deprecated properties from ontology

### DIFF
--- a/dco.ttl
+++ b/dco.ttl
@@ -638,13 +638,6 @@ dco:IGSN
       rdfs:label "IGSN"@en-US ;
       rdfs:range xsd:anyURI .
 
-##### Deprecated
-dco:projectUpdates
-      a       owl:DatatypeProperty ;
-      rdfs:domain vivo:Project ;
-      rdfs:label "project updates"@en-US ;
-      rdfs:range xsd:string .
-
 ##### DataTypes
 dco:DataType
       a       dco:Object , prov:Entity , owl:Class ;


### PR DESCRIPTION
dco:projectUpdates property is the old DatatypeProperty that was used in the summer of
2014 for the first pass at project updates. This property has since been
removed for a more expressive schema.
