### PR TITLE
Removing portal group and updating community props

### DIFF
--- a/dco-vivo.ttl
+++ b/dco-vivo.ttl
@@ -440,10 +440,12 @@ dco:relatedDataset
               "true"^^xsd:boolean .
 
 dco:skype
+      vitro:displayRankAnnot
+              "25"^^xsd:int ;
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:inPropertyGroupAnnot
-              <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+              <http://vivoweb.org/ontology#vitroPropertyGroupaddress> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 

--- a/dco-vivo.ttl
+++ b/dco-vivo.ttl
@@ -388,17 +388,6 @@ dco:Staff
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
-dco:Analysis
-      vitro:displayLimitAnnot
-              "-1"^^xsd:int ;
-      vitro:displayRankAnnot
-              "-1"^^xsd:int ;
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:inClassGroup <http://deepcarbon.net/vivo/individual/vitroClassGroupdcoactivities> ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
-
 dco:DataTypeParameter
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
@@ -512,17 +501,6 @@ dco:hasSampleAge
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
 
-dco:Outreach
-      vitro:displayLimitAnnot
-              "-1"^^xsd:int ;
-      vitro:displayRankAnnot
-              "-1"^^xsd:int ;
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGroupevents> ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
-
 dco:Technician
       vitro:hiddenFromDisplayBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
@@ -543,20 +521,6 @@ dco:hasLatitude
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:publicDescriptionAnnot
               "Latitude (in decimal units, e.g. 43.777874). Enter only one value!"^^xsd:string .
-
-dco:inOrganization
-      vitro:displayLimitAnnot
-              "5"^^xsd:int ;
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:inPropertyGroupAnnot
-              <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
-      vitro:offerCreateNewOptionAnnot
-              "true"^^xsd:boolean ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:selectFromExistingAnnot
-              "true"^^xsd:boolean .
 
 dco:containsChapter
       vitro:displayLimitAnnot
@@ -943,17 +907,6 @@ dco:submittedOn
       vitro:publicDescriptionAnnot
               "Project Updated submitted on YYYY-MM-DD"^^xsd:string .
 
-dco:PortalGroup
-      vitro:displayLimitAnnot
-              "-1"^^xsd:int ;
-      vitro:displayRankAnnot
-              "-1"^^xsd:int ;
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGrouporganizations> ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
-
 dco:distributionFor
       vitro:displayLimitAnnot
               "5"^^xsd:int ;
@@ -963,18 +916,6 @@ dco:distributionFor
               <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
       vitro:offerCreateNewOptionAnnot
               "true"^^xsd:boolean ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:selectFromExistingAnnot
-              "true"^^xsd:boolean .
-
-dco:hasPeople
-      vitro:displayLimitAnnot
-              "5"^^xsd:int ;
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:inPropertyGroupAnnot
-              <http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:selectFromExistingAnnot
@@ -1413,24 +1354,6 @@ dco:hasGeoSample
       vitro:selectFromExistingAnnot
               "true"^^xsd:boolean .
 
-dco:associatedDCOPortalGroup
-      vitro:displayLimitAnnot
-              "5"^^xsd:int ;
-      vitro:displayRankAnnot
-              "1"^^xsd:int ;
-      vitro:hiddenFromDisplayBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:hiddenFromPublishBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:inPropertyGroupAnnot
-              <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
-      vitro:offerCreateNewOptionAnnot
-              "true"^^xsd:boolean ;
-      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
-              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-      vitro:selectFromExistingAnnot
-              "true"^^xsd:boolean .
-
 dco:relatedOrganization
       vitro:displayLimitAnnot
               "5"^^xsd:int ;
@@ -1618,3 +1541,28 @@ dco:File
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
+
+dco:createdAtTime
+      vitro:displayRankAnnot
+              "3"^^xsd:int ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:hiddenFromPublishBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot
+              <http://vitro.mannlib.cornell.edu/ns/default#n2487> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
+
+dco:lastModifiedAtTime
+      vitro:displayRankAnnot
+              "100"^^xsd:int ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:hiddenFromPublishBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot
+              <http://vitro.mannlib.cornell.edu/ns/default#n2487> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> .
+

--- a/dco.ttl
+++ b/dco.ttl
@@ -140,17 +140,6 @@ dco:skype
       A person's identifier used for the Skype application.
       """^^rdf:XMLLiteral .
 
-dco:inOrganization
-      a       owl:ObjectProperty ;
-      rdfs:domain foaf:Person ;
-      rdfs:label "organization"@en-US ;
-      rdfs:range foaf:Organization ;
-      rdfs:subPropertyOf dco:inOrganization , owl:topObjectProperty ;
-      owl:inverseOf dco:hasPeople ;
-      rdfs:comment  """
-      Property which links a person with the organization that they play a role in.
-      """^^rdf:XMLLiteral .
-
 dco:shortName
       a       owl:DatatypeProperty ;
       rdfs:domain foaf:Person ;
@@ -731,11 +720,6 @@ dco:ResearchVessel
               ] ;
       rdfs:subClassOf
               [ a       owl:Restriction ;
-                owl:allValuesFrom dco:PortalGroup ;
-                owl:onProperty dco:associatedDCOPortalGroup
-              ] ;
-      rdfs:subClassOf
-              [ a       owl:Restriction ;
                 owl:allValuesFrom xsd:anyURI ;
                 owl:onProperty dco:vesselTrackingURL
               ] ;
@@ -1013,11 +997,6 @@ dco:Collaboration
       rdfs:subClassOf owl:Thing , dco:Object ;
       rdfs:subClassOf
               [ a       owl:Restriction ;
-                owl:allValuesFrom dco:PortalGroup ;
-                owl:onProperty dco:associatedDCOPortalGroup
-              ] ;
-      rdfs:subClassOf
-              [ a       owl:Restriction ;
                 owl:allValuesFrom dco:ResearchCommunity ;
                 owl:onProperty dco:associatedDCOCommunity
               ] ;
@@ -1029,22 +1008,11 @@ dco:Collaboration
 dco:ResearchCommunity
       a       owl:Class ;
       rdfs:label "Research Community"@en-US ;
-      rdfs:subClassOf vivo:ResearchOrganization , foaf:Organization , owl:Thing , foaf:Agent , dco:Object ;
+      rdfs:subClassOf foaf:Group , owl:Thing , foaf:Agent , dco:Object ;
       owl:equivalentClass dco:ResearchCommunity ;
       rdfs:comment  """
       A group of people who are working together in a specific science
       domain.
-      """^^rdf:XMLLiteral .
-
-dco:PortalGroup
-      a       owl:Class ;
-      rdfs:label "Portal Group"@en-US ;
-      rdfs:subClassOf foaf:Organization , owl:Thing , foaf:Agent , dco:Object ;
-      owl:equivalentClass dco:PortalGroup ;
-      rdfs:comment  """
-      A collaboration amongst 2 or more people working towards a common
-      goal. For example the Portal Development Group of the Deep Carbon
-      Observatory.
       """^^rdf:XMLLiteral .
 
 dco:Activity
@@ -1055,11 +1023,6 @@ dco:Activity
               [ a       owl:Restriction ;
                 owl:allValuesFrom dco:ResearchCommunity ;
                 owl:onProperty dco:associatedDCOCommunity
-              ] ;
-      rdfs:subClassOf
-              [ a       owl:Restriction ;
-                owl:allValuesFrom dco:PortalGroup ;
-                owl:onProperty dco:associatedDCOPortalGroup
               ] ;
       owl:equivalentClass dco:Activity ;
       rdfs:comment  """
@@ -1096,27 +1059,6 @@ dco:associatedDCOCommunity
       dataset.
       """^^rdf:XMLLiteral .
 
-dco:associatedDCOPortalGroup
-      a       owl:ObjectProperty ;
-      rdfs:label "associated DCO portal group"@en-US ;
-      rdfs:range dco:PortalGroup ;
-      rdfs:subPropertyOf dco:associatedDCOPortalGroup , owl:topObjectProperty ;
-      rdfs:comment  """
-      Relates a portal group to an entity such as a publication or
-      dataset.
-      """^^rdf:XMLLiteral .
-
-dco:hasPeople
-      a       owl:ObjectProperty ;
-      rdfs:domain foaf:Organization ;
-      rdfs:label "has people"@en-US ;
-      rdfs:range foaf:Person ;
-      rdfs:subPropertyOf owl:topObjectProperty , dco:hasPeople ;
-      owl:inverseOf dco:inOrganization ;
-      rdfs:comment  """
-      An individual who is a part of an organization.
-      """^^rdf:XMLLiteral .
-
 dco:relatedOrganization
       a       owl:ObjectProperty , owl:SymmetricProperty ;
       rdfs:domain foaf:Organization ;
@@ -1142,11 +1084,6 @@ dco:File
               [ a       owl:Restriction ;
                 owl:allValuesFrom rdfs:Literal ;
                 owl:onProperty dco:downloadURL
-              ] ;
-      rdfs:subClassOf
-              [ a       owl:Restriction ;
-                owl:allValuesFrom dco:PortalGroup ;
-                owl:onProperty dco:associatedDCOPortalGroup
               ] ;
       owl:equivalentClass dco:File ;
       rdfs:comment  """

--- a/dco.ttl
+++ b/dco.ttl
@@ -1024,6 +1024,11 @@ dco:Activity
                 owl:allValuesFrom dco:ResearchCommunity ;
                 owl:onProperty dco:associatedDCOCommunity
               ] ;
+      rdfs:subClassOf
+              [ a       owl:Restriction ;
+                owl:allValuesFrom dco:Team ;
+                owl:onProperty dco:associatedDCOTeam
+              ] ;
       owl:equivalentClass dco:Activity ;
       rdfs:comment  """
       Something that a person or group does or has done. For example,


### PR DESCRIPTION
Removed dco:PortalGroup, dco:associatedDCOPortalGroup from both .ttl
files. Removed classes from dco-vivo.ttl that aren't in dco.ttl. Added
properties to dco-vivo.ttl that were missing, using the weekly rdf
exports to fill in the blanks.
